### PR TITLE
fix overflow issue when using  infinite lifespans with negative offset timezones

### DIFF
--- a/shortener/shortener.py
+++ b/shortener/shortener.py
@@ -2,7 +2,7 @@ from shortener.models import UrlMap, UrlProfile
 from django.conf import settings
 from django.db import IntegrityError
 from django.db.models import F
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from django.utils import timezone
 
@@ -45,7 +45,10 @@ def create(user, link):
     if lifespan != -1:
         expiry_date = timezone.now() + timedelta(seconds=lifespan)
     else:
-        expiry_date = timezone.make_aware(timezone.datetime.max, timezone.get_default_timezone())
+        # Avoid using the absolute maximum date to avoid overflow issues
+        # when setting negative timezones
+        safe_max_date = datetime(datetime.max.year, 1, 1, tzinfo=timezone.get_default_timezone())
+        expiry_date = safe_max_date
 
     # Ensure user has not met max_urls quota
     if max_urls != -1:

--- a/tests/testapp/test_regressions.py
+++ b/tests/testapp/test_regressions.py
@@ -1,0 +1,15 @@
+from django.test import TestCase
+from shortener import shortener
+from shortener.models import UrlProfile
+from tests.testapp.models import CustomUser
+import time
+
+
+class RegressionsTestCase(TestCase):
+    def setUp(self):
+        self.bob = CustomUser.objects.create_user('bob', 'bob@bob.com', 'bobpassword')
+        self.alice = CustomUser.objects.create_user('alice', 'alice@alice.com', 'alicepassword')
+
+    def test_negative_timezone(self):
+        with self.settings(TIME_ZONE="America/New_York"):  # negative timezone UTC-5
+            shortener.create(self.bob, "https://devget.net/")


### PR DESCRIPTION
Fixes https://github.com/ronaldgrn/django-link-shortener/issues/8

---

Overflow caused by using datetime.max then attempting to set the timezone.

This would be fine for utc or any other positive tz but would fail for negative TZs.

Fixed by using 9999-01-01 as the expiry date for "infinte" shortlinks