### PR TITLE
add 'dictionary' parameter to shortener.create

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ django-link-shortener is a Django app for creating time-limited and usage-capped
 
 4.  Run `python manage.py migrate` to create the shortener models.
 
-5. Use `shortener.create(user, link)` to generate a shortcode.
+5.  Use `shortener.create(user, link)` to generate a shortcode.
 
     ```python
     from shortener import shortener
@@ -48,6 +48,17 @@ django-link-shortener is a Django app for creating time-limited and usage-capped
     user = User.objects.first()
     shortener.create(user, "https://example.com")
     ```
+
+    You can also pass a string representing a set of  characters, if you need control over which characters are allowed in a shortcode:
+
+    ```python
+    from shortener import shortener
+    
+    user = User.objects.first()
+    shortener.create(user, "https://example.com", "aeiou0123456789")
+    ```
+    The generated shortcode will only contain lowercase vowels and numeric digits.
+
 
 6. To expand the shortcode use `shortener.expand(shorlink_id)`, 
    or visit `http://127.0.0.1:8000/s/<shortcode>/`.

--- a/shortener/shortener.py
+++ b/shortener/shortener.py
@@ -8,17 +8,17 @@ from django.utils import timezone
 
 import random
 
+# Removed l, I, 1
+default_shortener_dictionary = "ABCDEFGHJKLMNOPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz234567890"
 
-def get_random(tries=0):
+def get_random(tries=0, dictionary=default_shortener_dictionary):
     length = getattr(settings, 'SHORTENER_LENGTH', 5)
     length += tries
 
-    # Removed l, I, 1
-    dictionary = "ABCDEFGHJKLMNOPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz234567890"
     return ''.join(random.choice(dictionary) for _ in range(length))
 
 
-def create(user, link):
+def create(user, link, dictionary=default_shortener_dictionary):
     # check if user allowed to save link
     try:
         # use user settings where set
@@ -64,7 +64,7 @@ def create(user, link):
     # Each time increase the number of allowed characters
     for tries in range(3):
         try:
-            short = get_random(tries)
+            short = get_random(tries, dictionary)
             m = UrlMap(user=user, full_url=link, short_url=short, max_count=max_uses, date_expired=expiry_date)
             m.save()
             return m.short_url

--- a/tests/testapp/tests.py
+++ b/tests/testapp/tests.py
@@ -14,6 +14,14 @@ class UrlMapTestCase(TestCase):
         url = shortener.create(self.bob, "http://devget.net/")
         self.assertEqual(shortener.expand(url), "http://devget.net/")
 
+    def test_url_creation_with_custom_dictionary(self):
+        url = shortener.create(self.bob, "http://devget.net/", "a")
+        self.assertEqual(url, "aaaaa")
+
+        url = shortener.create(self.bob, "http://devget.net/", "ab")
+        for digit in url:
+            self.assertIn(digit, "ab")
+
     def test_invalid_link(self):
         url = shortener.create(self.bob, "http://devget.net/")
         self.assertEqual(shortener.expand(url), "http://devget.net/")  # good shortlink


### PR DESCRIPTION
This PR adds an optional `dictionary` parameter to `shortener.create`. This allows the user to have control over which characters will be used when a shortcode is created. If no dictionary is provided, `shortener.create` will work as usual.

_Steps to test_
* Run `shortener.create(user, "https://someurl.com", "abcde")`. Verify that the generated shortcode is composed only by the "abcde" letters

* Run `shortener.create(user, "https://someurl.com")`. Verify that the shortcode is generated using the original logic of the project (uppercase an lowercase letters, digits, no confusing characters like '1' and 'l')